### PR TITLE
Updated Discord Link

### DIFF
--- a/src/utils/menu.js
+++ b/src/utils/menu.js
@@ -53,7 +53,7 @@ const menu = [
     name: 'Community',
     sublinks: [
       { name: 'Github', link: 'https://github.com/1hive' },
-      { name: 'Discord', link: 'https://discord.gg/w9QxYrB' },
+      { name: 'Discord', link: 'https://discord.gg/NTDBRNz' },
       { name: 'Discourse', link: 'https://forum.1hive.org' },
       { name: 'Twitter', link: 'https://twitter.com/1hiveorg' }
     ]


### PR DESCRIPTION
The Discord link provided in the footer was expired. I updated it to the correct invite link.