### PR TITLE
Remove menu background style

### DIFF
--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -62,7 +62,6 @@ const MenuFlyout = styled.span`
   min-width: 196px;
   padding: 0.5rem 1rem;
   border-radius: 12px;
-  background-color: ${({ theme }) => theme.menuBG};
   /* backdrop-filter: blur(20px); */
   box-shadow: 0px 0px 1px rgba(0, 0, 0, 0.04), 0px 4px 8px rgba(0, 0, 0, 0.04), 0px 16px 24px rgba(0, 0, 0, 0.04),
     0px 24px 32px rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
Before 

<img width="406" alt="Screen Shot 2021-12-03 at 2 04 58 PM" src="https://user-images.githubusercontent.com/11763623/144643193-37a62aba-b5ea-4a03-a3d1-7ea63056d33e.png">

After

<img width="710" alt="Screen Shot 2021-12-03 at 2 05 39 PM" src="https://user-images.githubusercontent.com/11763623/144643269-39402356-5924-4972-95e8-ee1e4561ccb7.png">

